### PR TITLE
Add a new path in sandbox for Xcode

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -74,6 +74,7 @@ class Sandbox
   # Xcode projects expect access to certain cache/archive dirs.
   def allow_write_xcode
     allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Developer"
+    allow_write_path "#{Dir.home(ENV.fetch("USER"))}/Library/Caches/org.swift.swiftpm"
   end
 
   def allow_write_log(formula)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example (https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). -> N/A
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally? -> Failures were unrelated to this PR.
- [ ] Have you successfully run `brew tests` with your changes locally? -> Failures were unrelated to this PR.

-----
When building a project which has SPM dependencies in Xcode, SPM will try and access (and potentially write in) `/Users/frizlab/Library/Caches/org.swift.swiftpm`.
I have added this path in the write exception for Xcode.